### PR TITLE
Changes to TOC.yml

### DIFF
--- a/docs-ref-conceptual/toc.yml
+++ b/docs-ref-conceptual/toc.yml
@@ -19,7 +19,7 @@
       items: 
         - name: Get started using Maven
           href: java-sdk-azure-get-started.md
-        - name: Get startedusing Eclipse
+        - name: Get started using Eclipse
           href: java-sdk-azure-get-started-eclipse.md
         - name: Get started using Intellij
           href: java-sdk-azure-get-started-intellij.md

--- a/docs-ref-conceptual/toc.yml
+++ b/docs-ref-conceptual/toc.yml
@@ -14,12 +14,15 @@
           href: /azure/postgresql/connect-java
         - name: Cosmos DB
           href: /azure/cosmos-db/create-documentdb-java
-    - name: Get started with Java 
-      href: java-sdk-azure-get-started.md
-    - name: Get started with Java using Eclipse
-      href: java-sdk-azure-get-started-eclipse.md
-    - name: Get started with Java using Intellij
-      href: java-sdk-azure-get-started-intellij.md
+    - name: Get started with the Java SDK
+      expanded: true
+      items: 
+        - name: Get started using Maven
+          href: java-sdk-azure-get-started.md
+        - name: Get startedusing Eclipse
+          href: java-sdk-azure-get-started-eclipse.md
+        - name: Get started using Intellij
+          href: java-sdk-azure-get-started-intellij.md
     - name: Tools
       href: java-azure-tools.md 
       items: 


### PR DESCRIPTION
Following up on a conversation that I had with RobertO, we'd like the TOC to reflect all of the Getting Started with the Java SDK articles under a new node.